### PR TITLE
Dev ops/grunt automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,12 +25,14 @@ npm-debug.log
 # Git ignore files for Typescript
 */*/*.js
 */*.js
-*.js
 
-# Ignore .css files 
+# Ignore .css files
 */*/*.css
 */*.css
 *.css
+
+# Ignore sass related files
+.sass-cache
 
 */*/*.map
 */*.map

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,36 @@
+module.exports = function(grunt) {
+	grunt.initConfig({
+		pkg: grunt.file.readJSON('package.json'),
+		sass: {
+			prod: {
+        files: [{
+           expand: true,
+           cwd: '',
+           src: ['app/**/*.scss'],
+           dest: '',
+           ext: '.css'
+         }]
+			}
+		},
+    cssmin: {
+      prod: {
+        files: [{
+           expand: true,
+           cwd: '',
+           src: ['app/**/*.css'],
+           dest: '',
+           ext: '.min.css'
+         }]
+      }
+    },
+    shell: {
+        startserver: {
+            command: 'npm start'
+        }
+    }
+	});
+	grunt.loadNpmTasks('grunt-contrib-sass');
+  grunt.loadNpmTasks('grunt-contrib-cssmin');
+  grunt.loadNpmTasks('grunt-shell');
+	grunt.registerTask('prod',['sass', 'cssmin', 'shell:startserver']);
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "grunt-contrib-uglify": "~0.5.0",
     "grunt-shell": "^1.2.1",
     "lite-server": "^2.0.1",
+    "normalize.css": "^3.0.3",
     "typescript": "^1.7.5"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,13 @@
   },
   "devDependencies": {
     "concurrently": "^1.0.0",
+    "grunt": "~0.4.5",
+    "grunt-contrib-cssmin": "^1.0.0",
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-nodeunit": "~0.4.1",
+    "grunt-contrib-sass": "~0.9.0",
+    "grunt-contrib-uglify": "~0.5.0",
+    "grunt-shell": "^1.2.1",
     "lite-server": "^2.0.1",
     "typescript": "^1.7.5"
   },


### PR DESCRIPTION
Added Grunt in order to compile sass files, minify css, compile .ts and start the server.

'npm start' is REPLACED with 'grunt prod'.
